### PR TITLE
Add support for Matomo >= 4.0.0 (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,22 @@ So here is a (hacky-ish) script that lets you specify all your configuration in 
     * Make sure you pay attention to the `document_root` - this should be the root directory of your Piwik install
 * Run the `install.php` script
     * eg. `php /opt/piwik/setup/install.php`
+* You may still need to run `php /opt/piwik/console core:update` to apply Matomo's migrations
 
 ## What version of Piwik does it work with?
 
-It has only been tested with Piwik Version 2.16.5
+It has only been tested with the following versions:
+* 2.16.5
+* 3.14.1
+* 4.0.3
+* 4.7.1
+
+## Troubleshooting
+
+> I can't log into Matomo, it keeps telling me to enable cookies and refresh
+
+You are probably running Matomo with multiple workers, and probably did not define `salt`. Register it and attribute it a randomly generated 32-character long hexadecimal string into the JSON file.
+This seems new since version 4.0.0. It seems they didn't really use the salt before.
 
 ## I hate it
 


### PR DESCRIPTION
- Define theme before anything else
- Change the way we detect database is working
- Add creation of security files, to comply with diagnostic reports
- Add the option to define a salt manually
  - This is required when having multiple workers, otherwise logging in will simply be impossible
- Remove calls to `console core:update`
  - When updating an existing installation, we most likely want to run and supervise migration ourselves